### PR TITLE
Shadow Walker: Door opening key field and inputs, SetSpeedModifier input

### DIFF
--- a/game/maplab/halloween.fgd
+++ b/game/maplab/halloween.fgd
@@ -45,6 +45,14 @@
 		0 : "Use One Squad Slot" 
 		1 : "Use Both Squad Slots" 
 	]
+	CannotOpenDoors(choices) : "Can Open Doors?" : 0 : "Is this NPC able to open doors? You can change this after spawning with EnableOpenDoors and DisableOpenDoors, but it doesn't always seem to work well with pathfinding." = 
+	[
+		0 : "Can Open Doors" 
+		1 : "Cannot Open Doors" 
+	]
+	input SetSpeedModifier(float) : "Set a float value to multiple distance traveled by."
+	input EnableOpenDoors(void) : "Allow this NPC to open doors. (Warning: Doesn't always seem to update pathfinding / AI)"
+	input DisableOpenDoors(void) : "Prevent this NPC from opening doors."
 ]
 
 @NPCClass base(npc_manhack) studio("models/skeleton/skeleton_torso3.mdl") = npc_lost_soul : "Lost Soul"

--- a/src/game/server/mod/npc_shadow_walker.cpp
+++ b/src/game/server/mod/npc_shadow_walker.cpp
@@ -60,7 +60,12 @@ public:
 
 	void			Activate();
 	void			FixupWeapon();
-	
+
+	// Inputs
+	virtual void InputSetSpeed(inputdata_t &inputdata);
+	virtual void InputEnableOpenDoors(inputdata_t &inputdata);
+	virtual void InputDisableOpenDoors(inputdata_t &inputdata);
+
 	DECLARE_DATADESC();
 
 	string_t m_iszWeaponModelName;			// Path/filename of model to override weapon model.
@@ -108,7 +113,11 @@ BEGIN_DATADESC(CNPC_ShadowWalker)
 	DEFINE_KEYFIELD(m_bCannotOpenDoors, FIELD_BOOLEAN, "CannotOpenDoors"),
 
 	DEFINE_FIELD(m_bWanderToggle, FIELD_BOOLEAN),
-	DEFINE_FIELD(m_flNextSoundTime, FIELD_TIME)
+	DEFINE_FIELD(m_flNextSoundTime, FIELD_TIME),
+
+	DEFINE_INPUTFUNC(FIELD_FLOAT, "SetSpeed", InputSetSpeed),
+	DEFINE_INPUTFUNC(FIELD_VOID, "EnableOpenDoors", InputEnableOpenDoors),
+	DEFINE_INPUTFUNC(FIELD_VOID, "DisableOpenDoors", InputDisableOpenDoors)
 END_DATADESC()
 
 //-----------------------------------------------------------------------------
@@ -565,6 +574,38 @@ void CNPC_ShadowWalker::PrecacheNPCSoundScript(string_t * SoundName, string_t de
 		*SoundName = defaultSoundName;
 	}
 	PrecacheScriptSound(STRING(*SoundName));
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Hammer input to change the speed of the NPC
+//-----------------------------------------------------------------------------
+void CNPC_ShadowWalker::InputSetSpeed(inputdata_t &inputdata)
+{
+	this->m_flSpeed = inputdata.value.Float();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Hammer input to enable opening doors
+//-----------------------------------------------------------------------------
+void CNPC_ShadowWalker::InputEnableOpenDoors(inputdata_t &inputdata)
+{
+	m_bCannotOpenDoors = true;
+	if (!HasSpawnFlags(SF_NPC_START_EFFICIENT))
+	{
+		CapabilitiesAdd(bits_CAP_DOORS_GROUP);
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Hammer input to enable opening doors
+//-----------------------------------------------------------------------------
+void CNPC_ShadowWalker::InputDisableOpenDoors(inputdata_t &inputdata)
+{
+	m_bCannotOpenDoors = false;
+	if (!HasSpawnFlags(SF_NPC_START_EFFICIENT))
+	{
+		CapabilitiesRemove(bits_CAP_DOORS_GROUP);
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/server/mod/npc_shadow_walker.cpp
+++ b/src/game/server/mod/npc_shadow_walker.cpp
@@ -81,6 +81,7 @@ private:
 
 
 	bool		m_bUseBothSquadSlots;	// If true use two squad slots, if false use one squad slot
+	bool		m_bCannotOpenDoors;		// If true, this NPC cannot open doors. The condition is reversed because originally it could.
 	bool		m_bWanderToggle;		// Boolean to toggle wandering / standing every think cycle
 	float		m_flNextSoundTime;		// Next time at which this NPC is allowed to play an NPC sound
 };
@@ -104,6 +105,7 @@ BEGIN_DATADESC(CNPC_ShadowWalker)
 	DEFINE_KEYFIELD(m_iszLostEnemySound, FIELD_SOUNDNAME, "LostEnemySound"),
 	DEFINE_KEYFIELD(m_iszFoundEnemySound, FIELD_SOUNDNAME, "FoundEnemySound"),
 	DEFINE_KEYFIELD(m_bUseBothSquadSlots, FIELD_BOOLEAN, "UseBothSquadSlots"),
+	DEFINE_KEYFIELD(m_bCannotOpenDoors, FIELD_BOOLEAN, "CannotOpenDoors"),
 
 	DEFINE_FIELD(m_bWanderToggle, FIELD_BOOLEAN),
 	DEFINE_FIELD(m_flNextSoundTime, FIELD_TIME)
@@ -203,8 +205,12 @@ void CNPC_ShadowWalker::Spawn( void )
 		CapabilitiesAdd(bits_CAP_USE_WEAPONS | bits_CAP_AIM_GUN | bits_CAP_MOVE_SHOOT);
 		CapabilitiesAdd(bits_CAP_WEAPON_MELEE_ATTACK1 || bits_CAP_WEAPON_MELEE_ATTACK2);
 		CapabilitiesAdd(bits_CAP_INNATE_MELEE_ATTACK1 || bits_CAP_INNATE_MELEE_ATTACK2);
-		CapabilitiesAdd(bits_CAP_DUCK | bits_CAP_DOORS_GROUP);
+		CapabilitiesAdd(bits_CAP_DUCK);
 		CapabilitiesAdd(bits_CAP_USE_SHOT_REGULATOR);
+
+		if (!m_bCannotOpenDoors) {
+			CapabilitiesAdd(bits_CAP_DOORS_GROUP);
+		}
 	}
 
 	CapabilitiesAdd(bits_CAP_MOVE_GROUND);


### PR DESCRIPTION
I have added one key field and three inputs to npc_shadow_walker. These changes do not affect maps made before the changes.

The key "Can Open Doors?" sets whether the enemy represented by npc_shadow_walker should be able to open doors. It defaults to 'Can Open Doors' to stay consistent with the original mod template that was released, in which npc_shadow_walker could open doors.

The inputs EnableOpenDoors and DisableOpenDoors will toggle this behavior on and off. I have also added an input "SetSpeedModifier" that will multiply all distances the shadow walker travels by a provided float value. This could be useful for a variety of maps where speed needs to be adjusted for balancing.