### PR TITLE
Shadow Walker: Fixed bug that replaced custom weapons with crowbars upon loading a saved game

### DIFF
--- a/sp/game/mod_episodic/scripts/weapon_custommelee.txt
+++ b/sp/game/mod_episodic/scripts/weapon_custommelee.txt
@@ -1,0 +1,22 @@
+// Custom melee weapon - used by npc_shadow_walker for weapon model overrides
+WeaponData
+{
+	// This will be replaced in code
+	"playermodel"			"models/weapons/w_crowbar.mdl"
+
+	"anim_prefix"			"crowbar"
+
+	"clip_size"				"-1"
+	"primary_ammo"			"None"
+	"secondary_ammo"		"None"
+
+	"weight"				"0"
+	"item_flags"			"0"
+
+	// Sounds for the weapon. There is a max of 16 sounds per category (i.e. max 16 "single_shot" sounds)
+	SoundData
+	{
+		"melee_hit_world"	"Weapon_Crowbar.Melee_HitWorld"
+	}
+
+}

--- a/sp/game/mod_episodic/scripts/weapon_manifest.txt
+++ b/sp/game/mod_episodic/scripts/weapon_manifest.txt
@@ -1,0 +1,24 @@
+weapon_manifest
+{
+	"file"		"scripts/weapon_357.txt"
+	"file"		"scripts/weapon_alyxgun.txt"
+	"file"		"scripts/weapon_annabelle.txt"
+	"file"		"scripts/weapon_ar2.txt"
+	"file"		"scripts/weapon_bugbait.txt"
+	"file"		"scripts/weapon_citizenpackage.txt"
+	"file"		"scripts/weapon_citizensuitcase.txt"
+	"file"		"scripts/weapon_crossbow.txt"
+	"file"		"scripts/weapon_crowbar.txt"
+	"file"		"scripts/weapon_cubemap.txt"
+	"file"		"scripts/weapon_frag.txt"
+	"file"		"scripts/weapon_physcannon.txt"
+	"file"		"scripts/weapon_physgun.txt"
+	"file"		"scripts/weapon_pistol.txt"
+	"file"		"scripts/weapon_rpg.txt"
+	"file"		"scripts/weapon_shotgun.txt"
+	"file"		"scripts/weapon_smg1.txt"
+	"file"		"scripts/weapon_stunstick.txt"
+	
+	// Custom
+	"file"		"scripts/weapon_custommelee.txt"	
+}

--- a/src/game/server/mod/npc_shadow_walker.cpp
+++ b/src/game/server/mod/npc_shadow_walker.cpp
@@ -127,12 +127,13 @@ void CNPC_ShadowWalker::FixupWeapon()
 	// If no weapons supplied, give a crowbar
 	CBaseCombatWeapon *pWeapon = GetActiveWeapon();
 	if (pWeapon == NULL) {
-		CWeaponCustomMelee * pMeleeWeapon = (CWeaponCustomMelee *)CREATE_UNSAVED_ENTITY(CWeaponCustomMelee, "weapon_crowbar");
+		CWeaponCustomMelee *pMeleeWeapon = (CWeaponCustomMelee*)CreateEntityByName("weapon_custommelee");
 
 		// Apply weapon model override
 		if (&m_iszWeaponModelName && m_iszWeaponModelName != MAKE_STRING("")) {
 			pMeleeWeapon->m_iszWeaponModelName = this->m_iszWeaponModelName;
 		}
+		// Default custom weapon model
 		else {
 			pMeleeWeapon->m_iszWeaponModelName = MAKE_STRING("models/props_canal/mattpipe.mdl");
 		}

--- a/src/game/server/mod/npc_shadow_walker.cpp
+++ b/src/game/server/mod/npc_shadow_walker.cpp
@@ -11,186 +11,19 @@
 //
 //=============================================================================//
 #include "cbase.h"
-#include "ai_default.h"
-#include "ai_task.h"
-#include "ai_schedule.h"
+#include "npc_shadow_walker.h"
 #include "ai_hull.h"
 #include "soundent.h"
 #include "game.h"
 #include "npcevent.h"
-#include "entitylist.h"
-#include "activitylist.h"
-#include "ai_basenpc.h"
-#include "ai_blended_movement.h"
-#include "ai_behavior_actbusy.h"
 #include "engine/IEngineSound.h"
 #include "basehlcombatweapon_shared.h"
 #include "ai_squadslot.h"
-#include "weapon_crowbar.h"
+#include "weapon_custom_melee.h"
+
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
-
-//=========================================================
-// schedules
-//=========================================================
-enum
-{
-	SCHED_MELEE_ATTACK_NOINTERRUPT = LAST_SHARED_SCHEDULE,
-	SCHED_HIDE,
-
-	LAST_SHADOW_WALKER_SCHED
-};
-
-//=========================================================
-//=========================================================
-typedef CAI_BlendingHost< CAI_BehaviorHost<CAI_BaseNPC> > CAI_CustomNPCBase;
-
-class CNPC_ShadowWalker : public CAI_CustomNPCBase
-{
-	DECLARE_CLASS( CNPC_ShadowWalker, CAI_CustomNPCBase);
-
-public:
-	void	Precache( void );
-	void	Spawn( void );
-	Class_T Classify( void );
-	virtual int				SelectFailSchedule(int failedSchedule, int failedTask, AI_TaskFailureCode_t taskFailCode);
-	virtual int 			SelectScheduleRetrieveItem();
-	virtual int 			SelectScheduleWander();
-	virtual int 			SelectSchedule();
-	virtual int				SelectIdleSchedule();
-	virtual int				SelectAlertSchedule();
-	virtual int				SelectCombatSchedule();
-	virtual float			GetSequenceGroundSpeed(CStudioHdr *pStudioHdr, int iSequence);
-	virtual Activity				NPC_TranslateActivity(Activity eNewActivity);
-	virtual int TranslateSchedule(int scheduleType);
-
-	// Sounds
-	virtual void		PlaySound(string_t soundname, bool optional);
-	virtual void		DeathSound(const CTakeDamageInfo &info) { PlaySound(m_iszDeathSound, true); }
-	virtual void		AlertSound(void) { PlaySound(m_iszAlertSound, false); };
-	virtual void		IdleSound(void) { PlaySound(m_iszIdleSound, false); };
-	virtual void		PainSound(const CTakeDamageInfo &info) { PlaySound(m_iszPainSound, true); };
-	virtual void		FearSound(void) { PlaySound(m_iszFearSound, false); };
-	virtual void		LostEnemySound(void) { PlaySound(m_iszLostEnemySound, false); };
-	virtual void		FoundEnemySound(void);
-
-	void			Activate();
-	void			FixupWeapon();
-
-	// Inputs
-	virtual void InputSetSpeedModifier(inputdata_t &inputdata);
-	virtual void InputEnableOpenDoors(inputdata_t &inputdata);
-	virtual void InputDisableOpenDoors(inputdata_t &inputdata);
-	virtual void InputEnablePickupWeapons(inputdata_t &inputdata);
-	virtual void InputDisablePickupWeapons(inputdata_t &inputdata);
-
-	DECLARE_DATADESC();
-
-	string_t m_iszWeaponModelName;			// Path/filename of model to override weapon model.
-
-	string_t m_iszFearSound;			// Path/filename of WAV file to play.
-	string_t m_iszDeathSound;			// Path/filename of WAV file to play.
-	string_t m_iszIdleSound;			// Path/filename of WAV file to play.
-	string_t m_iszPainSound;			// Path/filename of WAV file to play.
-	string_t m_iszAlertSound;			// Path/filename of WAV file to play.
-	string_t m_iszLostEnemySound;		// Path/filename of WAV file to play.
-	string_t m_iszFoundEnemySound;		// Path/filename of WAV file to play.
-
-	DEFINE_CUSTOM_AI;
-
-private:
-	bool		HasRangedWeapon();
-	void		PrecacheNPCSoundScript(string_t* SoundName, string_t defaultSoundName);
-
-
-	bool		m_bUseBothSquadSlots;	// If true use two squad slots, if false use one squad slot
-	bool		m_bCannotOpenDoors;		// If true, this NPC cannot open doors. The condition is reversed because originally it could.
-	bool		m_bCanPickupWeapons;			// If true, this NPC is able to pick up weapons off of the ground just like npc_citizen.
-	bool		m_bWanderToggle;		// Boolean to toggle wandering / standing every think cycle
-	float		m_flNextSoundTime;		// Next time at which this NPC is allowed to play an NPC sound
-	float		m_flNextFoundEnemySoundTime;	// Next time at which this NPC is allowed to play an NPC sound
-	float		m_flSpeedModifier;		// Modifier to apply to move distance
-};
-
-
-LINK_ENTITY_TO_CLASS( npc_shadow_walker, CNPC_ShadowWalker );
-//IMPLEMENT_CUSTOM_AI( npc_citizen,CNPC_ShadowWalker );
-
-
-//---------------------------------------------------------
-// Save/Restore
-//---------------------------------------------------------
-BEGIN_DATADESC(CNPC_ShadowWalker)
-	DEFINE_KEYFIELD(m_iszWeaponModelName, FIELD_STRING, "WeaponModel"),
-	DEFINE_KEYFIELD(m_iHealth, FIELD_INTEGER, "Health"),
-	DEFINE_KEYFIELD(m_iszFearSound, FIELD_SOUNDNAME, "FearSound"),
-	DEFINE_KEYFIELD(m_iszDeathSound, FIELD_SOUNDNAME, "DeathSound"),
-	DEFINE_KEYFIELD(m_iszIdleSound, FIELD_SOUNDNAME, "IdleSound"),
-	DEFINE_KEYFIELD(m_iszPainSound, FIELD_SOUNDNAME, "PainSound"),
-	DEFINE_KEYFIELD(m_iszAlertSound, FIELD_SOUNDNAME, "AlertSound"),
-	DEFINE_KEYFIELD(m_iszLostEnemySound, FIELD_SOUNDNAME, "LostEnemySound"),
-	DEFINE_KEYFIELD(m_iszFoundEnemySound, FIELD_SOUNDNAME, "FoundEnemySound"),
-	DEFINE_KEYFIELD(m_bUseBothSquadSlots, FIELD_BOOLEAN, "UseBothSquadSlots"),
-	DEFINE_KEYFIELD(m_bCannotOpenDoors, FIELD_BOOLEAN, "CannotOpenDoors"),
-	DEFINE_KEYFIELD(m_bCanPickupWeapons, FIELD_BOOLEAN, "CanPickupWeapons"),
-
-	DEFINE_FIELD(m_bWanderToggle, FIELD_BOOLEAN),
-	DEFINE_FIELD(m_flNextSoundTime, FIELD_TIME),
-	DEFINE_FIELD(m_flNextFoundEnemySoundTime, FIELD_TIME),
-	DEFINE_FIELD(m_flSpeedModifier, FIELD_TIME),
-
-	DEFINE_INPUTFUNC(FIELD_FLOAT, "SetSpeedModifier", InputSetSpeedModifier),
-	DEFINE_INPUTFUNC(FIELD_VOID, "EnableOpenDoors", InputEnableOpenDoors),
-	DEFINE_INPUTFUNC(FIELD_VOID, "DisableOpenDoors", InputDisableOpenDoors),
-	DEFINE_INPUTFUNC(FIELD_VOID, "EnablePickupWeapons", InputEnablePickupWeapons),
-	DEFINE_INPUTFUNC(FIELD_VOID, "DisablePickupWeapons", InputDisablePickupWeapons)
-END_DATADESC()
-
-
-AI_BEGIN_CUSTOM_NPC(npc_shadow_walker, CNPC_ShadowWalker)
-//=========================================================
-// > Melee_Attack_NoInterrupt
-//=========================================================
-DEFINE_SCHEDULE
-(
-	SCHED_MELEE_ATTACK_NOINTERRUPT,
-
-	"	Tasks"
-	"		TASK_STOP_MOVING		0"
-	"		TASK_FACE_ENEMY			0"
-	"		TASK_ANNOUNCE_ATTACK	1"	// 1 = primary attack
-	"		TASK_MELEE_ATTACK1		0"
-	""
-	"	Interrupts"
-	"		COND_ENEMY_DEAD"
-	"		COND_ENEMY_OCCLUDED"
-);
-
-//=========================================================
-// 	SCHED_HIDE
-//=========================================================
-DEFINE_SCHEDULE
-(
-	SCHED_HIDE,
-
-	"	Tasks"
-	"		TASK_SET_FAIL_SCHEDULE		SCHEDULE:SCHED_COMBAT_FACE"
-	"		TASK_STOP_MOVING			0"
-	"		TASK_FIND_COVER_FROM_ENEMY	0"
-	"		TASK_RUN_PATH				0"
-	"		TASK_WAIT_FOR_MOVEMENT		0"
-	"		TASK_REMEMBER				MEMORY:INCOVER"
-	"		TASK_FACE_ENEMY				0"
-	""
-	"	Interrupts"
-	"		COND_HEAR_DANGER"
-	"		COND_NEW_ENEMY"
-	"		COND_ENEMY_DEAD"
-);
-AI_END_CUSTOM_NPC()
-
-
 
 //---------------------------------------------------------
 // Constants
@@ -199,18 +32,6 @@ const float MIN_TIME_NEXT_SOUND = 0.5f;
 const float MAX_TIME_NEXT_SOUND = 1.0f;
 const float MIN_TIME_NEXT_FOUNDENEMY_SOUND = 2.0f;
 const float MAX_TIME_NEXT_FOUNDENEMY_SOUND = 5.0f;
-
-//-----------------------------------------------------------------------------
-// Purpose: Inner class for default weapon
-// TODO: Merge this with the Matt weapon in npc_citizen
-//-----------------------------------------------------------------------------
-class CWeaponCustomMelee : public CWeaponCrowbar
-{
-	DECLARE_CLASS(CWeaponCustomMelee, CWeaponCrowbar);
-
-	const char *GetWorldModel() const { return GetModelName().ToCStr(); }
-	void SetPickupTouch(void) {	/* do nothing */ }
-};
 
 //-----------------------------------------------------------------------------
 // Purpose: 
@@ -281,11 +102,10 @@ void CNPC_ShadowWalker::Spawn( void )
 
 	if (!HasSpawnFlags(SF_NPC_START_EFFICIENT))
 	{
-		CapabilitiesAdd(bits_CAP_TURN_HEAD);
+		CapabilitiesAdd(bits_CAP_ANIMATEDFACE | bits_CAP_TURN_HEAD); // The default model has no face animations, but a custom model might
 		CapabilitiesAdd(bits_CAP_SQUAD);
 		CapabilitiesAdd(bits_CAP_USE_WEAPONS | bits_CAP_AIM_GUN | bits_CAP_MOVE_SHOOT);
 		CapabilitiesAdd(bits_CAP_WEAPON_MELEE_ATTACK1 || bits_CAP_WEAPON_MELEE_ATTACK2);
-		CapabilitiesAdd(bits_CAP_INNATE_MELEE_ATTACK1 || bits_CAP_INNATE_MELEE_ATTACK2);
 		CapabilitiesAdd(bits_CAP_DUCK);
 		CapabilitiesAdd(bits_CAP_USE_SHOT_REGULATOR);
 
@@ -307,20 +127,21 @@ void CNPC_ShadowWalker::FixupWeapon()
 	// If no weapons supplied, give a crowbar
 	CBaseCombatWeapon *pWeapon = GetActiveWeapon();
 	if (pWeapon == NULL) {
-		pWeapon = (CBaseCombatWeapon *)CREATE_UNSAVED_ENTITY(CWeaponCustomMelee, "weapon_crowbar");
+		CWeaponCustomMelee * pMeleeWeapon = (CWeaponCustomMelee *)CREATE_UNSAVED_ENTITY(CWeaponCustomMelee, "weapon_crowbar");
 
 		// Apply weapon model override
 		if (&m_iszWeaponModelName && m_iszWeaponModelName != MAKE_STRING("")) {
-			pWeapon->SetModel(STRING(m_iszWeaponModelName));
+			pMeleeWeapon->m_iszWeaponModelName = this->m_iszWeaponModelName;
 		}
 		else {
-			pWeapon->SetModel("models/props_canal/mattpipe.mdl");
+			pMeleeWeapon->m_iszWeaponModelName = MAKE_STRING("models/props_canal/mattpipe.mdl");
 		}
+
+		pWeapon = (CBaseCombatWeapon *)pMeleeWeapon;
 
 		DispatchSpawn(pWeapon);
 		Weapon_Equip(pWeapon);
 	}
-
 
 }
 

--- a/src/game/server/mod/npc_shadow_walker.h
+++ b/src/game/server/mod/npc_shadow_walker.h
@@ -40,19 +40,19 @@ class CNPC_ShadowWalker : public CAI_CustomNPCBase
 	DECLARE_CLASS(CNPC_ShadowWalker, CAI_CustomNPCBase);
 
 public:
-	void	Precache(void);
-	void	Spawn(void);
-	Class_T Classify(void);
-	virtual int				SelectFailSchedule(int failedSchedule, int failedTask, AI_TaskFailureCode_t taskFailCode);
-	virtual int 			SelectScheduleRetrieveItem();
-	virtual int 			SelectScheduleWander();
-	virtual int 			SelectSchedule();
-	virtual int				SelectIdleSchedule();
-	virtual int				SelectAlertSchedule();
-	virtual int				SelectCombatSchedule();
-	virtual float			GetSequenceGroundSpeed(CStudioHdr *pStudioHdr, int iSequence);
-	virtual Activity				NPC_TranslateActivity(Activity eNewActivity);
-	virtual int TranslateSchedule(int scheduleType);
+	void				Precache(void);
+	void				Spawn(void);
+	Class_T				Classify(void);
+	virtual int			SelectFailSchedule(int failedSchedule, int failedTask, AI_TaskFailureCode_t taskFailCode);
+	virtual int 		SelectScheduleRetrieveItem();
+	virtual int 		SelectScheduleWander();
+	virtual int 		SelectSchedule();
+	virtual int			SelectIdleSchedule();
+	virtual int			SelectAlertSchedule();
+	virtual int			SelectCombatSchedule();
+	virtual float		GetSequenceGroundSpeed(CStudioHdr *pStudioHdr, int iSequence);
+	virtual Activity	NPC_TranslateActivity(Activity eNewActivity);
+	virtual int			TranslateSchedule(int scheduleType);
 
 	// Sounds
 	virtual void		PlaySound(string_t soundname, bool optional);
@@ -64,42 +64,42 @@ public:
 	virtual void		LostEnemySound(void) { PlaySound(m_iszLostEnemySound, false); };
 	virtual void		FoundEnemySound(void);
 
-	void			Activate();
-	void			FixupWeapon();
+	void				Activate();
+	void				FixupWeapon();
 
 	// Inputs
-	virtual void InputSetSpeedModifier(inputdata_t &inputdata);
-	virtual void InputEnableOpenDoors(inputdata_t &inputdata);
-	virtual void InputDisableOpenDoors(inputdata_t &inputdata);
-	virtual void InputEnablePickupWeapons(inputdata_t &inputdata);
-	virtual void InputDisablePickupWeapons(inputdata_t &inputdata);
+	virtual void		InputSetSpeedModifier(inputdata_t &inputdata);
+	virtual void		InputEnableOpenDoors(inputdata_t &inputdata);
+	virtual void		InputDisableOpenDoors(inputdata_t &inputdata);
+	virtual void		InputEnablePickupWeapons(inputdata_t &inputdata);
+	virtual void		InputDisablePickupWeapons(inputdata_t &inputdata);
 
 	DECLARE_DATADESC();
 
-	string_t m_iszWeaponModelName;			// Path/filename of model to override weapon model.
+	string_t			m_iszWeaponModelName;			// Path/filename of model to override weapon model.
 
-	string_t m_iszFearSound;			// Path/filename of WAV file to play.
-	string_t m_iszDeathSound;			// Path/filename of WAV file to play.
-	string_t m_iszIdleSound;			// Path/filename of WAV file to play.
-	string_t m_iszPainSound;			// Path/filename of WAV file to play.
-	string_t m_iszAlertSound;			// Path/filename of WAV file to play.
-	string_t m_iszLostEnemySound;		// Path/filename of WAV file to play.
-	string_t m_iszFoundEnemySound;		// Path/filename of WAV file to play.
+	string_t			m_iszFearSound;			// Path/filename of WAV file to play.
+	string_t			m_iszDeathSound;			// Path/filename of WAV file to play.
+	string_t			m_iszIdleSound;			// Path/filename of WAV file to play.
+	string_t			m_iszPainSound;			// Path/filename of WAV file to play.
+	string_t			m_iszAlertSound;			// Path/filename of WAV file to play.
+	string_t			m_iszLostEnemySound;		// Path/filename of WAV file to play.
+	string_t			m_iszFoundEnemySound;		// Path/filename of WAV file to play.
 
 	DEFINE_CUSTOM_AI;
 
 private:
-	bool		HasRangedWeapon();
-	void		PrecacheNPCSoundScript(string_t* SoundName, string_t defaultSoundName);
+	bool				HasRangedWeapon();
+	void				PrecacheNPCSoundScript(string_t* SoundName, string_t defaultSoundName);
 
 
-	bool		m_bUseBothSquadSlots;	// If true use two squad slots, if false use one squad slot
-	bool		m_bCannotOpenDoors;		// If true, this NPC cannot open doors. The condition is reversed because originally it could.
-	bool		m_bCanPickupWeapons;			// If true, this NPC is able to pick up weapons off of the ground just like npc_citizen.
-	bool		m_bWanderToggle;		// Boolean to toggle wandering / standing every think cycle
-	float		m_flNextSoundTime;		// Next time at which this NPC is allowed to play an NPC sound
-	float		m_flNextFoundEnemySoundTime;	// Next time at which this NPC is allowed to play an NPC sound
-	float		m_flSpeedModifier;		// Modifier to apply to move distance
+	bool				m_bUseBothSquadSlots;	// If true use two squad slots, if false use one squad slot
+	bool				m_bCannotOpenDoors;		// If true, this NPC cannot open doors. The condition is reversed because originally it could.
+	bool				m_bCanPickupWeapons;			// If true, this NPC is able to pick up weapons off of the ground just like npc_citizen.
+	bool				m_bWanderToggle;		// Boolean to toggle wandering / standing every think cycle
+	float				m_flNextSoundTime;		// Next time at which this NPC is allowed to play an NPC sound
+	float				m_flNextFoundEnemySoundTime;	// Next time at which this NPC is allowed to play an NPC sound
+	float				m_flSpeedModifier;		// Modifier to apply to move distance
 };
 
 

--- a/src/game/server/mod/npc_shadow_walker.h
+++ b/src/game/server/mod/npc_shadow_walker.h
@@ -1,0 +1,179 @@
+//=//=============================================================================//
+//
+// Purpose: A malevolent being from a parallel universe which at one point
+//		may have been human.		
+//
+//		npc_shadow_walker is designed to be reusable as a generic horror 
+//		game style npc. Its model and sound files may be configured through
+//		the hammer editor using keyfields.
+//
+//	Author: 1upD
+//
+//=============================================================================//
+#include "cbase.h"
+#include "ai_default.h"
+#include "ai_task.h"
+#include "ai_schedule.h"
+#include "entitylist.h"
+#include "activitylist.h"
+#include "ai_basenpc.h"
+#include "ai_blended_movement.h"
+#include "ai_behavior_actbusy.h"
+
+//=========================================================
+// schedules
+//=========================================================
+enum
+{
+	SCHED_MELEE_ATTACK_NOINTERRUPT = LAST_SHARED_SCHEDULE,
+	SCHED_HIDE,
+
+	LAST_SHADOW_WALKER_SCHED
+};
+
+//=========================================================
+//=========================================================
+typedef CAI_BlendingHost< CAI_BehaviorHost<CAI_BaseNPC> > CAI_CustomNPCBase;
+
+class CNPC_ShadowWalker : public CAI_CustomNPCBase
+{
+	DECLARE_CLASS(CNPC_ShadowWalker, CAI_CustomNPCBase);
+
+public:
+	void	Precache(void);
+	void	Spawn(void);
+	Class_T Classify(void);
+	virtual int				SelectFailSchedule(int failedSchedule, int failedTask, AI_TaskFailureCode_t taskFailCode);
+	virtual int 			SelectScheduleRetrieveItem();
+	virtual int 			SelectScheduleWander();
+	virtual int 			SelectSchedule();
+	virtual int				SelectIdleSchedule();
+	virtual int				SelectAlertSchedule();
+	virtual int				SelectCombatSchedule();
+	virtual float			GetSequenceGroundSpeed(CStudioHdr *pStudioHdr, int iSequence);
+	virtual Activity				NPC_TranslateActivity(Activity eNewActivity);
+	virtual int TranslateSchedule(int scheduleType);
+
+	// Sounds
+	virtual void		PlaySound(string_t soundname, bool optional);
+	virtual void		DeathSound(const CTakeDamageInfo &info) { PlaySound(m_iszDeathSound, true); }
+	virtual void		AlertSound(void) { PlaySound(m_iszAlertSound, false); };
+	virtual void		IdleSound(void) { PlaySound(m_iszIdleSound, false); };
+	virtual void		PainSound(const CTakeDamageInfo &info) { PlaySound(m_iszPainSound, true); };
+	virtual void		FearSound(void) { PlaySound(m_iszFearSound, false); };
+	virtual void		LostEnemySound(void) { PlaySound(m_iszLostEnemySound, false); };
+	virtual void		FoundEnemySound(void);
+
+	void			Activate();
+	void			FixupWeapon();
+
+	// Inputs
+	virtual void InputSetSpeedModifier(inputdata_t &inputdata);
+	virtual void InputEnableOpenDoors(inputdata_t &inputdata);
+	virtual void InputDisableOpenDoors(inputdata_t &inputdata);
+	virtual void InputEnablePickupWeapons(inputdata_t &inputdata);
+	virtual void InputDisablePickupWeapons(inputdata_t &inputdata);
+
+	DECLARE_DATADESC();
+
+	string_t m_iszWeaponModelName;			// Path/filename of model to override weapon model.
+
+	string_t m_iszFearSound;			// Path/filename of WAV file to play.
+	string_t m_iszDeathSound;			// Path/filename of WAV file to play.
+	string_t m_iszIdleSound;			// Path/filename of WAV file to play.
+	string_t m_iszPainSound;			// Path/filename of WAV file to play.
+	string_t m_iszAlertSound;			// Path/filename of WAV file to play.
+	string_t m_iszLostEnemySound;		// Path/filename of WAV file to play.
+	string_t m_iszFoundEnemySound;		// Path/filename of WAV file to play.
+
+	DEFINE_CUSTOM_AI;
+
+private:
+	bool		HasRangedWeapon();
+	void		PrecacheNPCSoundScript(string_t* SoundName, string_t defaultSoundName);
+
+
+	bool		m_bUseBothSquadSlots;	// If true use two squad slots, if false use one squad slot
+	bool		m_bCannotOpenDoors;		// If true, this NPC cannot open doors. The condition is reversed because originally it could.
+	bool		m_bCanPickupWeapons;			// If true, this NPC is able to pick up weapons off of the ground just like npc_citizen.
+	bool		m_bWanderToggle;		// Boolean to toggle wandering / standing every think cycle
+	float		m_flNextSoundTime;		// Next time at which this NPC is allowed to play an NPC sound
+	float		m_flNextFoundEnemySoundTime;	// Next time at which this NPC is allowed to play an NPC sound
+	float		m_flSpeedModifier;		// Modifier to apply to move distance
+};
+
+
+LINK_ENTITY_TO_CLASS(npc_shadow_walker, CNPC_ShadowWalker);
+
+//---------------------------------------------------------
+// Save/Restore
+//---------------------------------------------------------
+BEGIN_DATADESC(CNPC_ShadowWalker)
+DEFINE_KEYFIELD(m_iszWeaponModelName, FIELD_STRING, "WeaponModel"),
+DEFINE_KEYFIELD(m_iHealth, FIELD_INTEGER, "Health"),
+DEFINE_KEYFIELD(m_iszFearSound, FIELD_SOUNDNAME, "FearSound"),
+DEFINE_KEYFIELD(m_iszDeathSound, FIELD_SOUNDNAME, "DeathSound"),
+DEFINE_KEYFIELD(m_iszIdleSound, FIELD_SOUNDNAME, "IdleSound"),
+DEFINE_KEYFIELD(m_iszPainSound, FIELD_SOUNDNAME, "PainSound"),
+DEFINE_KEYFIELD(m_iszAlertSound, FIELD_SOUNDNAME, "AlertSound"),
+DEFINE_KEYFIELD(m_iszLostEnemySound, FIELD_SOUNDNAME, "LostEnemySound"),
+DEFINE_KEYFIELD(m_iszFoundEnemySound, FIELD_SOUNDNAME, "FoundEnemySound"),
+DEFINE_KEYFIELD(m_bUseBothSquadSlots, FIELD_BOOLEAN, "UseBothSquadSlots"),
+DEFINE_KEYFIELD(m_bCannotOpenDoors, FIELD_BOOLEAN, "CannotOpenDoors"),
+DEFINE_KEYFIELD(m_bCanPickupWeapons, FIELD_BOOLEAN, "CanPickupWeapons"),
+
+DEFINE_FIELD(m_bWanderToggle, FIELD_BOOLEAN),
+DEFINE_FIELD(m_flNextSoundTime, FIELD_TIME),
+DEFINE_FIELD(m_flNextFoundEnemySoundTime, FIELD_TIME),
+DEFINE_FIELD(m_flSpeedModifier, FIELD_TIME),
+
+DEFINE_INPUTFUNC(FIELD_FLOAT, "SetSpeedModifier", InputSetSpeedModifier),
+DEFINE_INPUTFUNC(FIELD_VOID, "EnableOpenDoors", InputEnableOpenDoors),
+DEFINE_INPUTFUNC(FIELD_VOID, "DisableOpenDoors", InputDisableOpenDoors),
+DEFINE_INPUTFUNC(FIELD_VOID, "EnablePickupWeapons", InputEnablePickupWeapons),
+DEFINE_INPUTFUNC(FIELD_VOID, "DisablePickupWeapons", InputDisablePickupWeapons)
+END_DATADESC()
+
+
+AI_BEGIN_CUSTOM_NPC(npc_shadow_walker, CNPC_ShadowWalker)
+//=========================================================
+// > Melee_Attack_NoInterrupt
+//=========================================================
+DEFINE_SCHEDULE
+(
+	SCHED_MELEE_ATTACK_NOINTERRUPT,
+
+	"	Tasks"
+	"		TASK_STOP_MOVING		0"
+	"		TASK_FACE_ENEMY			0"
+	"		TASK_ANNOUNCE_ATTACK	1"	// 1 = primary attack
+	"		TASK_MELEE_ATTACK1		0"
+	""
+	"	Interrupts"
+	"		COND_ENEMY_DEAD"
+	"		COND_ENEMY_OCCLUDED"
+);
+
+//=========================================================
+// 	SCHED_HIDE
+//=========================================================
+DEFINE_SCHEDULE
+(
+	SCHED_HIDE,
+
+	"	Tasks"
+	"		TASK_SET_FAIL_SCHEDULE		SCHEDULE:SCHED_COMBAT_FACE"
+	"		TASK_STOP_MOVING			0"
+	"		TASK_FIND_COVER_FROM_ENEMY	0"
+	"		TASK_RUN_PATH				0"
+	"		TASK_WAIT_FOR_MOVEMENT		0"
+	"		TASK_REMEMBER				MEMORY:INCOVER"
+	"		TASK_FACE_ENEMY				0"
+	""
+	"	Interrupts"
+	"		COND_HEAR_DANGER"
+	"		COND_NEW_ENEMY"
+	"		COND_ENEMY_DEAD"
+);
+AI_END_CUSTOM_NPC()
+

--- a/src/game/server/mod/weapon_custom_melee.h
+++ b/src/game/server/mod/weapon_custom_melee.h
@@ -1,0 +1,28 @@
+//=//=============================================================================//
+//
+// Purpose: Melee weapon for custom NPCs. Its model can be overridden.
+//
+//	Author: 1upD
+//
+//=============================================================================//
+#include "cbase.h"
+#include "basehlcombatweapon_shared.h"
+#include "weapon_crowbar.h"
+
+
+class CWeaponCustomMelee : public CWeaponCrowbar
+{
+	DECLARE_CLASS(CWeaponCustomMelee, CWeaponCrowbar);
+
+	const char *GetWorldModel() const { return m_iszWeaponModelName.ToCStr(); }
+	void SetPickupTouch(void) {	/* do nothing */ }
+public:
+	string_t m_iszWeaponModelName;
+
+	DECLARE_DATADESC();
+
+};
+
+BEGIN_DATADESC(CWeaponCustomMelee)
+DEFINE_FIELD(m_iszWeaponModelName, FIELD_STRING)
+END_DATADESC()

--- a/src/game/server/mod/weapon_custom_melee.h
+++ b/src/game/server/mod/weapon_custom_melee.h
@@ -15,14 +15,21 @@ class CWeaponCustomMelee : public CWeaponCrowbar
 	DECLARE_CLASS(CWeaponCustomMelee, CWeaponCrowbar);
 
 	const char *GetWorldModel() const { return m_iszWeaponModelName.ToCStr(); }
-	void SetPickupTouch(void) {	/* do nothing */ }
+	virtual void Drop(const Vector &vecVelocity);
 public:
 	string_t m_iszWeaponModelName;
 
 	DECLARE_DATADESC();
-
 };
 
+void CWeaponCustomMelee::Drop(const Vector &vecVelocity)
+{
+	BaseClass::Drop(vecVelocity);
+	AddSpawnFlags(SF_WEAPON_NO_PLAYER_PICKUP);
+}
+
+LINK_ENTITY_TO_CLASS(weapon_custommelee, CWeaponCustomMelee);
+
 BEGIN_DATADESC(CWeaponCustomMelee)
-DEFINE_FIELD(m_iszWeaponModelName, FIELD_STRING)
+	DEFINE_FIELD(m_iszWeaponModelName, FIELD_STRING)
 END_DATADESC()

--- a/src/game/server/server_maplab.vpc
+++ b/src/game/server/server_maplab.vpc
@@ -38,8 +38,10 @@ $Project "Server (MapLab)"
 			$File   "lab\lab_player.cpp"
 			$File   "lab\lab_player.h"
 
-			$File	"mod\npc_lost_soul.cpp"
-			$File	"mod\npc_shadow_walker.cpp"
+			$File "mod\npc_lost_soul.cpp"
+			$File "mod\npc_shadow_walker.h"
+			$File "mod\npc_shadow_walker.cpp"
+			$File "mod\weapon_custom_melee.h"
 		}
 		
 	}


### PR DESCRIPTION
I heavily refactored the npc_shadow_walker code and extracted the custom melee weapon into its own class. weapon_custommelee is now its own classname, so dropped weapons will not become crowbars upon loading a previously saved game.

There are a couple of compatibility issues to understand before accepting this pull request:
- Previously, dropped custom weapons could be picked up with the interact key. This is no longer the case - if any mappers required dropped weapons to be used to solve puzzles, these maps will be broken. To my knowledge no such puzzles were made. (Dropped crowbars will still be interactable and dropped stun sticks will still be treated as suit batteries, as usual) 
- The new weapon script for the custom melee weapon is required to be added to the mod, otherwise this code will break all maps that use npc_shadow_walker with a custom melee weapon... please be sure not to forget these weapon scripts!