### PR TITLE
"Hack" input on Alyx-interactable NPCs (e.g. rollermines)

### DIFF
--- a/src/game/server/ai_basenpc.h
+++ b/src/game/server/ai_basenpc.h
@@ -3062,7 +3062,8 @@ public:
 #define	DEFINE_BASENPCINTERACTABLE_DATADESC() \
 	DEFINE_OUTPUT( m_OnAlyxStartedInteraction,				"OnAlyxStartedInteraction" ),	\
 	DEFINE_OUTPUT( m_OnAlyxFinishedInteraction,				"OnAlyxFinishedInteraction" ),  \
-	DEFINE_INPUTFUNC( FIELD_VOID, "InteractivePowerDown", InputPowerdown )
+	DEFINE_INPUTFUNC( FIELD_VOID, "InteractivePowerDown", InputPowerdown ), \
+	DEFINE_INPUTFUNC( FIELD_VOID, "Hack", InputDoInteraction )
 
 template <class NPC_CLASS>
 class CNPCBaseInteractive : public NPC_CLASS, public INPCInteractive
@@ -3076,6 +3077,11 @@ public:
 	virtual void	InputPowerdown( inputdata_t &inputdata )
 	{
 
+	}
+	
+	virtual void	InputDoInteraction( inputdata_t &inputdata )
+	{
+		NotifyInteraction(inputdata.pActivator ? inputdata.pActivator->MyNPCPointer() : NULL);
 	}
 
 	// Alyx specific interactions


### PR DESCRIPTION
I felt guilty from people being disappointed that there's no way to hack rollermines in vanilla HL2 without Alyx. This code is from Mapbase. I hope this isn't too late to be used for the Valentine's Day competition.

A keyvalue version for rollermines would require changing DEFINE_FIELD( m_bHackedByAlyx, FIELD_BOOLEAN ), in npc_rollermine.cpp to a keyfield. You could do that if you want, but this should work on its own.