### PR TITLE
Crabless Zombies

### DIFF
--- a/game/maplab/fgd/halflife2.fgd
+++ b/game/maplab/fgd/halflife2.fgd
@@ -1565,30 +1565,39 @@
 [
 ]
 
-@NPCClass base(BaseNPC) studio("models/Zombie/fast.mdl") = npc_fastzombie : "Fast Zombie"
+@BaseClass base(BaseNPC ) = BaseZombie
+[
+	Headless(choices) : "Has Headcrab?" : 0 =
+	[
+		0 : "Has Headcrab"
+		1 : "No Headcrab"
+	]
+]
+
+@NPCClass base(BaseZombie) studio("models/Zombie/fast.mdl") = npc_fastzombie : "Fast Zombie"
 [
 	input AttachToVehicle(string) : "Attach to a specified vehicle entity"
 ]
 
-@NPCClass base(BaseNPC) studio("models/Zombie/Fast_torso.mdl") = npc_fastzombie_torso : "Fast Zombie Torso"
+@NPCClass base(BaseZombie) studio("models/Zombie/Fast_torso.mdl") = npc_fastzombie_torso : "Fast Zombie Torso"
 [
 
 ]
 
-@NPCClass base(BaseNPC) studio("models/Zombie/Classic.mdl") = npc_zombie : "Zombie"
+@NPCClass base(BaseZombie) studio("models/Zombie/Classic.mdl") = npc_zombie : "Zombie"
 [
 ]
 
-@NPCClass base(BaseNPC) studio("models/Zombie/Classic_torso.mdl") = npc_zombie_torso : "Zombie Torso"
+@NPCClass base(BaseZombie) studio("models/Zombie/Classic_torso.mdl") = npc_zombie_torso : "Zombie Torso"
 [
 ]
 
-@NPCClass base(BaseNPC) studio("models/Zombie/zombie_soldier.mdl") = npc_zombine : "Combine Soldier Zombie"
+@NPCClass base(BaseZombie) studio("models/Zombie/zombie_soldier.mdl") = npc_zombine : "Combine Soldier Zombie"
 [
 	input StartSprint(void) : "Forces the zombine to sprint."
 	input PullGrenade(void) : "Forces the zombine to pull a grenade."
 ]
-@NPCClass base(BaseNPC) studio("models/Zombie/Poison.mdl") = npc_poisonzombie :
+@NPCClass base(BaseZombie) studio("models/Zombie/Poison.mdl") = npc_poisonzombie :
 	"A bloated, disgusting, fluid-spurting zombie created by a poison headcrab."
 [
 	crabcount(choices) : "Crabs in nest" : 3 =

--- a/src/game/server/hl2/npc_BaseZombie.cpp
+++ b/src/game/server/hl2/npc_BaseZombie.cpp
@@ -205,7 +205,7 @@ BEGIN_DATADESC( CNPC_BaseZombie )
 
 	DEFINE_SOUNDPATCH( m_pMoanSound ),
 	DEFINE_FIELD( m_fIsTorso, FIELD_BOOLEAN ),
-	DEFINE_FIELD( m_fIsHeadless, FIELD_BOOLEAN ),
+	DEFINE_KEYFIELD( m_fIsHeadless, FIELD_BOOLEAN, "Headless" ),
 	DEFINE_FIELD( m_flNextFlinch, FIELD_TIME ),
 	DEFINE_FIELD( m_bHeadShot, FIELD_BOOLEAN ),
 	DEFINE_FIELD( m_flBurnDamage, FIELD_FLOAT ),
@@ -761,7 +761,7 @@ bool CNPC_BaseZombie::ShouldBecomeTorso( const CTakeDamageInfo &info, float flDa
 //-----------------------------------------------------------------------------
 HeadcrabRelease_t CNPC_BaseZombie::ShouldReleaseHeadcrab( const CTakeDamageInfo &info, float flDamageThreshold )
 {
-	if ( m_iHealth <= 0 )
+	if ( m_iHealth <= 0 && !this->m_fIsHeadless)
 	{
 		if ( info.GetDamageType() & DMG_REMOVENORAGDOLL )
 			return RELEASE_NO;

--- a/src/game/server/hl2/npc_PoisonZombie.cpp
+++ b/src/game/server/hl2/npc_PoisonZombie.cpp
@@ -285,7 +285,7 @@ void CNPC_PoisonZombie::Spawn( void )
 {
 	Precache();
 
-	m_fIsTorso = m_fIsHeadless = false;
+	m_fIsTorso = false;
 
 #ifdef HL2_EPISODIC
 	SetBloodColor( BLOOD_COLOR_ZOMBIE );

--- a/src/game/server/hl2/npc_fastzombie.cpp
+++ b/src/game/server/hl2/npc_fastzombie.cpp
@@ -652,7 +652,7 @@ void CFastZombie::Spawn( void )
 
 	m_fJustJumped = false;
 
-	m_fIsTorso = m_fIsHeadless = false;
+	m_fIsTorso = false;
 
 	if( FClassnameIs( this, "npc_fastzombie" ) )
 	{

--- a/src/game/server/hl2/npc_zombie.cpp
+++ b/src/game/server/hl2/npc_zombie.cpp
@@ -273,8 +273,6 @@ void CZombie::Spawn( void )
 		m_fIsTorso = true;
 	}
 
-	m_fIsHeadless = false;
-
 #ifdef HL2_EPISODIC
 	SetBloodColor( BLOOD_COLOR_ZOMBIE );
 #else

--- a/src/game/server/hl2/npc_zombine.cpp
+++ b/src/game/server/hl2/npc_zombine.cpp
@@ -201,7 +201,6 @@ void CNPC_Zombine::Spawn( void )
 	Precache();
 
 	m_fIsTorso = false;
-	m_fIsHeadless = false;
 	
 #ifdef HL2_EPISODIC
 	SetBloodColor( BLOOD_COLOR_ZOMBIE );


### PR DESCRIPTION
By request, I have added a new keyvalue for all zombie types that simply removes the headcrab on a zombie's head.  (Poison zombies will always carry at least one poison headcrab on their backs)

This code is from Mapbase (particularly made by Blixibon) with permission, but it should remain compatible and the same if and when MapLabs starts running on Mapbase.