### PR TITLE
Hide 'Node Graph out of Date. Rebuilding...'

### DIFF
--- a/src/game/server/ai_networkmanager.cpp
+++ b/src/game/server/ai_networkmanager.cpp
@@ -1110,7 +1110,10 @@ void CAI_NetworkManager::DelayedInit( void )
 #endif
 
 			DevMsg( "Node Graph out of Date. Rebuilding... (%d, %d, %d)\n", (int)m_bDontSaveGraph, (int)!CAI_NetworkManager::NetworksLoaded(), (int) engine->IsInEditMode() );
-			UTIL_CenterPrintAll( "Node Graph out of Date. Rebuilding...\n" );
+			
+			if ( developer.GetBool() )
+				UTIL_CenterPrintAll( "Node Graph out of Date. Rebuilding...\n" );
+			
 			m_bNeedGraphRebuild = true;
 			g_pAINetworkManager->SetNextThink( gpGlobals->curtime + 1 );
 			return;


### PR DESCRIPTION
This code makes the forsaken message of 'Node Graph out of Date. Rebuilding...' to appear when in developer mode.